### PR TITLE
Avoid undefined behaviour with `grampc->param->Np == 0`

### DIFF
--- a/src/grampc_run.c
+++ b/src/grampc_run.c
@@ -316,7 +316,8 @@ void evaluate_constraints(ctypeRNum *t, ctypeRNum *u, ctypeRNum *p, const typeBo
 			cfctprev = grampc->rws->cfctprev + i * grampc->param->Nc;
 			dcdx = grampc->rws->dcdx + i * grampc->param->Nx;
 			dcdu = grampc->rws->dcdu + i * grampc->param->Nu;
-			dcdp = grampc->rws->dcdp + i * grampc->param->Np;
+			if (grampc->rws->dcdp)
+				dcdp = grampc->rws->dcdp + i * grampc->param->Np;
 			thresholds = grampc->rws->cfctAbsTol;
 			cScale = grampc->opt->cScale;
 


### PR DESCRIPTION
When running grampc with `grampc->param->Np == 0`, the code invoked Undefined Behaviour several times, mostly because `memcpy` involving NULL is currently undefined (even if the length is 0), and even NULL + 0 is undefined.

These issues will be fixed in a future C standard (see https://developers.redhat.com/articles/2024/12/11/making-memcpynull-null-0-well-defined ) but currently they are undefined behaviour and could cause e.g. crashes.

Found by UBSan.